### PR TITLE
Fix auth reset

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -24,7 +24,12 @@ import {
 import { waitDOMReady, sleep, scrollIntoView } from "./utils.js";
 
 import Head from "./head.jsx";
-import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
+import {
+	BrowserRouter as Router,
+	Route,
+	Switch,
+	Redirect,
+} from "react-router-dom";
 import { ScrollContext } from "react-router-scroll-4";
 import { Provider, connect } from "react-redux";
 import AddArticle from "./add.jsx";
@@ -64,6 +69,11 @@ class App extends Component {
 								)}
 							/>
 							<Route
+								path="/admin/"
+								exact={true}
+								render={() => <Redirect to="/login/" />}
+							/>
+							<Route
 								path="/deleted/"
 								exact={true}
 								render={() => (
@@ -94,16 +104,25 @@ class App extends Component {
 								exact={true}
 								render={() => <Feeds {...this.props} />}
 							/>
-							<Route path="/sort/" render={() => <Sorter {...this.props} />} />
+							<Route
+								path="/sort/"
+								render={() => (
+									<ScrollContext>
+										<Sorter {...this.props} />
+									</ScrollContext>
+								)}
+							/>
 							<Route
 								path={`${postsPrefix}/:slug`}
-								render={props =>
-									this.props.isAdmin ? (
-										<EditableArticle slug={props.match.params.slug} />
-									) : (
-										<Article slug={props.match.params.slug} />
-									)
-								}
+								render={props => (
+									<ScrollContext>
+										{this.props.isAdmin ? (
+											<EditableArticle slug={props.match.params.slug} />
+										) : (
+											<Article slug={props.match.params.slug} />
+										)}
+									</ScrollContext>
+								)}
 							/>
 							<Route path="/login/" exact={true} render={() => <LoginForm />} />
 							<Route component={NotFound} />

--- a/src/utils.js
+++ b/src/utils.js
@@ -53,11 +53,13 @@ export async function waitDOMReady() {
 	}
 }
 
-export async function retry(fn, retries = 3) {
+export async function retry(fn, retries = 3, retryInterval = 0) {
 	for (let i = 0; i < retries; i++) {
 		try {
 			return await fn();
-		} catch (e) {}
+		} catch (e) {
+			if (retryInterval) await sleep(retryInterval);
+		}
 	}
 	throw new Error("Retry failed");
 }


### PR DESCRIPTION
Внес исправление в то место где куки сохраняются, надеюсь поможет, потому как проблему воспроизвести не смог.
Если не поможет, то тогда думаю уместным будет поставить логгинг вокруг этой операции и отсматривать в случае повторения.

P.S кстати, а есть какой-то эндпоинт где можно проверить правильность аутентификации? Сейчас при каждом заходе ui делает `PUT /api/v1/news/reload` и проверяет, что пришел статус 200. Так было на прошлой версии, так что вряд ли тут проблема, но все как-то не идемпотентно :-)

P.P.S не знаю почему @bobuk удивился про "u shall not pass" — так тоже на прошлой версии было