### PR TITLE
Fix article content in dark theme

### DIFF
--- a/src/style.scss
+++ b/src/style.scss
@@ -1278,6 +1278,10 @@ html[data-theme="night"] {
 		}
 	}
 
+	.header__show-start-counter {
+		opacity: 0.6;
+	}
+
 	.sorter__comments-link {
 		opacity: 0.7;
 		fill: rgba(255, 255, 255, 0.8);

--- a/src/style.scss
+++ b/src/style.scss
@@ -1045,10 +1045,14 @@ p {
 		position: relative;
 		z-index: 2;
 		margin-top: 0.6rem;
-		background: rgba(0, 0, 0, 0.03);
+		background-color: rgba(0, 0, 0, 0.03);
 
 		display: flex;
 		flex-direction: row;
+
+		.post-active & {
+			background: transparentize($color: #fff, $amount: 0.34);
+		}
 	}
 
 	&__full-content .loading {
@@ -1240,7 +1244,9 @@ p {
 /* NIGHT THEME */
 
 html[data-theme="night"] {
-	background: hsl(40, 10%, 12%);
+	$backgoundColor: hsl(40, 10%, 12%);
+	$activeBackgroundColor: hsla(40, 90%, 90%, 0.2);
+	background-color: $backgoundColor;
 	color: #ddd;
 
 	a,
@@ -1278,7 +1284,7 @@ html[data-theme="night"] {
 	}
 
 	.sorter__item-current {
-		background: hsla(40, 90%, 90%, 0.2);
+		background-color: $activeBackgroundColor;
 	}
 
 	/* add-form-overlay */
@@ -1339,12 +1345,12 @@ html[data-theme="night"] {
 	@media (hover: hover) {
 		.listing-actions__news-recent-button:hover,
 		.listing-actions__news-recent-button:focus {
-			background: hsla(200, 60%, 60%, 0.2);
+			background-color: hsla(200, 60%, 60%, 0.2);
 		}
 
 		.listing-actions__news-recent-button-active:hover,
 		.listing-actions__news-recent-button-active:focus {
-			background: hsla(200, 60%, 60%, 0.7);
+			background-color: hsla(200, 60%, 60%, 0.7);
 		}
 	}
 
@@ -1361,7 +1367,7 @@ html[data-theme="night"] {
 	/* post */
 
 	.post-active {
-		background: hsla(40, 90%, 90%, 0.2);
+		background-color: hsla(40, 90%, 90%, 0.2);
 	}
 
 	.post__title-link {
@@ -1375,22 +1381,28 @@ html[data-theme="night"] {
 	}
 
 	.post__full-content {
-		background: rgba(255, 255, 255, 0.23);
+		background-color: rgba(255, 255, 255, 0.15);
+		box-shadow: 0px 0px 2px #000;
 	}
 
 	.post__full-content-hide {
 		color: rgba(255, 255, 255, 0.2);
-		background: rgba(255, 255, 255, 0.13);
+		background-color: rgba(255, 255, 255, 0.13);
 	}
 
 	.post__full-content-hide:hover {
-		background: rgba(255, 255, 255, 0.26);
+		background-color: rgba(255, 255, 255, 0.26);
+	}
+
+	.post-active .post__full-content {
+		background-color: transparentize($color: $backgoundColor, $amount: 0.2);
+		box-shadow: none;
 	}
 
 	/* article */
 
 	.article__snippet {
-		background: hsla(40, 60%, 90%, 0.2);
+		background-color: hsla(40, 60%, 90%, 0.2);
 	}
 
 	/* drop */
@@ -1403,12 +1415,12 @@ html[data-theme="night"] {
 
 	/* touch-drag */
 	.touch-drag-item__start {
-		background: rgba(0, 0, 0, 0);
+		background-color: rgba(0, 0, 0, 0);
 	}
 
 	.touch-drag-item {
 		box-shadow: none;
-		background: hsla(200, 70%, 80%, 0.5);
+		background-color: hsla(200, 70%, 80%, 0.5);
 	}
 
 	.touch-drag-target-top {


### PR DESCRIPTION
Поправил вот это безобразие:
![screen shot 2018-12-23 at 01 13 53](https://user-images.githubusercontent.com/884649/50379409-3ce56280-065a-11e9-9dde-fd1da2d3ab3c.png)
Теперь так: 
![screen shot 2018-12-23 at 01 45 30](https://user-images.githubusercontent.com/884649/50379415-5090c900-065a-11e9-81e5-88d07130d100.png)

По поводу гиттера:
Там такая же проблема как у ремарка была. Айфрейм и никакого способа задать стиль внутри. Есть какая-то переписка из 2016го, и видимо ничего не изменилось: https://gitter.im/gitterHQ/sidecar/archives/2016/02/06

Ты сказал еще, что белый попап тебе не нравится, ты же про этот?:
![screen shot 2018-12-23 at 02 24 58](https://user-images.githubusercontent.com/884649/50379449-1673f700-065b-11e9-95cc-08afe0ae60d3.png)

Это стандартный пропмт в сафари, отрисованный osx. В файрфоксе он например вот так виглядит: 
![screen shot 2018-12-23 at 02 31 57](https://user-images.githubusercontent.com/884649/50379452-2095f580-065b-11e9-9062-40bca31c25fe.png)
Если прямо сильно бьет по чувству прекрасного, то можно и на js написать.


