### PR TITLE
Add dependabot.yml to disable npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
Configure dependabot.yml to disable npm package updates by setting open-pull-requests-limit to 0.