### PR TITLE
Add dependency grouping to dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 0
+    groups:
+      "all-dependencies":
+        patterns:
+          - "*"
+        dependency-type: all


### PR DESCRIPTION
Should get rid of security updates for good this time.